### PR TITLE
Fix multiple files bug

### DIFF
--- a/verify_docs.py
+++ b/verify_docs.py
@@ -7,18 +7,18 @@
 import yaml
 import sys
 errored = False
-yfile = sys.argv[1]
-with open(yfile, 'r') as ymlfile:
-    cfg = yaml.load(ymlfile)
+for yfile in sys.argv[1:]:
+    with open(yfile, 'r') as ymlfile:
+        cfg = yaml.load(ymlfile)
 
-for i in cfg["paths"]:
-    for j in cfg["paths"][i]:
-        k = cfg["paths"][i][j]
+    for i in cfg["paths"]:
+        for j in cfg["paths"][i]:
+            k = cfg["paths"][i][j]
 
-        if "summary" not in k:
-            print "Error: summary missing from Swagger doc in: ", i
-            errored = True
-        if "tags" in k:
-            print "Error: tags exists in, %s, remove it" % (i)
+            if "summary" not in k:
+                print "Error: summary missing from Swagger doc in:", i
+                errored = True
+            if "tags" in k:
+                print "Error: tags exists in, %s, remove it" % (i)
 
 sys.exit(errored)

--- a/verify_docs.py
+++ b/verify_docs.py
@@ -4,21 +4,26 @@
 #
 # returns an exit code accordingly
 
-import yaml
 import sys
-errored = False
-for yfile in sys.argv[1:]:
-    with open(yfile, 'r') as ymlfile:
-        cfg = yaml.load(ymlfile)
+import yaml
 
-    for i in cfg["paths"]:
-        for j in cfg["paths"][i]:
-            k = cfg["paths"][i][j]
+def verify_docs_files(files):
+    errored = False
+    for yfile in files:
+        with open(yfile, 'r') as ymlfile:
+            cfg = yaml.load(ymlfile)
 
-            if "summary" not in k:
-                print "Error: summary missing from Swagger doc in:", i
-                errored = True
-            if "tags" in k:
-                print "Error: tags exists in, %s, remove it" % (i)
+        for i in cfg["paths"]:
+            for j in cfg["paths"][i]:
+                k = cfg["paths"][i][j]
 
-sys.exit(errored)
+                if "summary" not in k:
+                    print("Error: summary missing from Swagger doc in: %s " % (i))
+                    errored = True
+                if "tags" in k:
+                    print("Error: tags exists in, %s, remove it" % (i))
+
+    return errored
+
+if __name__ == "__main__":
+    sys.exit(verify_docs_files(sys.argv[1:]))


### PR DESCRIPTION
```
commit 721cc2f2e716098275f392a8bcd299bb819a8fb9
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Fri Jun 21 14:20:00 2019 +0200

    Make script verify_docs.py Python 3 compatible
    
    And encapsulate the logic in a method, so that it could be imported from
    other Python code.
    
    Changelog: Title
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>

commit 69d778013d29f82f050d5018f2a7e1a075c2355a
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Fri Jun 21 14:15:22 2019 +0200

    Bugfix: verify all files passed as arguments, not only the first one
    
    Changelog: Title
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>

```
