### PR TITLE
[verify_docs] Remove buggy check for tags

### DIFF
--- a/verify_docs.py
+++ b/verify_docs.py
@@ -20,8 +20,6 @@ def verify_docs_files(files):
                 if "summary" not in k:
                     print("Error: summary missing from Swagger doc in: %s " % (i))
                     errored = True
-                if "tags" in k:
-                    print("Error: tags exists in, %s, remove it" % (i))
 
     return errored
 


### PR DESCRIPTION
We are now introducing tags to differentiate plans in Enterprise specs,
so we need to allow them.

(Also, the check was buggy so had no actual effect).