### PR TITLE
explicitly set loader on yaml loading

### DIFF
--- a/verify_docs.py
+++ b/verify_docs.py
@@ -11,7 +11,7 @@ def verify_docs_files(files):
     errored = False
     for yfile in files:
         with open(yfile, 'r') as ymlfile:
-            cfg = yaml.load(ymlfile)
+            cfg = yaml.load(ymlfile, Loader=yaml.SafeLoader)
 
         for i in cfg["paths"]:
             for j in cfg["paths"][i]:


### PR DESCRIPTION
- this is to circumvent deprecation of the default loader in pyyaml

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>